### PR TITLE
Fix: Repair the logic for obtaining the configuration file path.

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,13 @@ type config struct {
 }
 
 func readConfig() *config {
-	content, err := os.ReadFile("config.json")
+	var configPath string
+	if len(os.Args) > 1 {
+		configPath = os.Args[1]
+	} else {
+		configPath = "config.json"
+	}
+	content, err := os.ReadFile(configPath)
 	if nil != err {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Fixed the logic for obtaining the configuration file path to ensure that config.json is used as the default when no command line arguments are provided.