### PR TITLE
fix idea chat 不可用(2023.2)版本

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ import (
     "math/rand"
 )
 
+
+
 const DefaultInstructModel = "gpt-3.5-turbo-instruct"
 
 const StableCodeModelPrefix = "stable-code"
@@ -206,6 +208,8 @@ func (s *ProxyService) InitRoutes(e *gin.Engine) {
 			v1.POST("/v1/engines/copilot-codex/completions", s.codeCompletions)
 		}
 	} else {
+		e.POST("/chat/completions", s.completions)
+		e.POST("/engines/copilot-codex/completions", s.codeCompletions)
 		e.POST("/v1/chat/completions", s.completions)
 		e.POST("/v1/engines/copilot-codex/completions", s.codeCompletions)
 


### PR DESCRIPTION
vscode使用正常 idea异常。
![image](https://github.com/user-attachments/assets/ae69c9ea-2b61-4f8d-b09e-6f3cc8df201e)
发现 idea 请求的接口是/chat/com 不带v1
代码中 非auth没有增加这个接口路由，补充此接口路由