### PR TITLE
为Dockerfile中添加替换alpine镜像源命令

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o override
 
 FROM alpine:latest
 
+RUN sed -i 's#https\?://dl-cdn.alpinelinux.org/alpine#https://mirrors.tuna.tsinghua.edu.cn/alpine#g' /etc/apk/repositories
+
 RUN apk --no-cache add ca-certificates
 
 COPY --from=builder /app/override /usr/local/bin/


### PR DESCRIPTION
解决神奇的网络问题
```
Step 8/14 : RUN apk --no-cache add ca-certificates
 ---> Running in a525d7759627
fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/main/x86_64/APKINDEX.tar.gz WARNING: fetching https://dl-cdn.alpinelinux.org/alpine/v3.20/main: temporary error (try again later) fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/community/x86_64/APKINDEX.tar.gz WARNING: fetching https://dl-cdn.alpinelinux.org/alpine/v3.20/community: temporary error (try again later) ERROR: unable to select packages:
  ca-certificates (no such package):
    required by: world[ca-certificates]
The command '/bin/sh -c apk --no-cache add ca-certificates' returned a non-zero code: 1
```