### PR TITLE
security: stop logging code completion API keys

### DIFF
--- a/main.go
+++ b/main.go
@@ -552,13 +552,6 @@ func getRandomApiKey(paramStr string) string {
     randomIndex := rand.Intn(len(params))
 	fmt.Println("Code completion API Key index:", randomIndex)
 	key := strings.TrimSpace(params[randomIndex])
-	maskedKey := key
-	if len(key) > 12 {
-		maskedKey = key[:4] + "..." + key[len(key)-4:]
-	} else if len(key) > 0 {
-		maskedKey = "******"
-	}
-	fmt.Println("Code completion API Key:", maskedKey)
     return key
 }
 

--- a/main.go
+++ b/main.go
@@ -551,8 +551,15 @@ func getRandomApiKey(paramStr string) string {
     rand.Seed(time.Now().UnixNano())
     randomIndex := rand.Intn(len(params))
 	fmt.Println("Code completion API Key index:", randomIndex)
-	fmt.Println("Code completion API Key:", strings.TrimSpace(params[randomIndex]))
-    return strings.TrimSpace(params[randomIndex])
+	key := strings.TrimSpace(params[randomIndex])
+	maskedKey := key
+	if len(key) > 12 {
+		maskedKey = key[:4] + "..." + key[len(key)-4:]
+	} else if len(key) > 0 {
+		maskedKey = "******"
+	}
+	fmt.Println("Code completion API Key:", maskedKey)
+    return key
 }
 
 func ConstructRequestBody(body []byte, cfg *config) []byte {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	originalStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+
+	os.Stdout = writer
+	fn()
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
+	}
+	os.Stdout = originalStdout
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close stdout reader: %v", err)
+	}
+
+	return string(output)
+}
+
+func TestGetRandomApiKeyDoesNotLogKeyMaterial(t *testing.T) {
+	testCases := []struct {
+		name string
+		key  string
+	}{
+		{name: "long key", key: "sk-super-secret-completion-key-1234567890"},
+		{name: "short key", key: "short-key"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var selectedKey string
+			output := captureStdout(t, func() {
+				selectedKey = getRandomApiKey(testCase.key)
+			})
+
+			if selectedKey != testCase.key {
+				t.Fatalf("selected key = %q, want %q", selectedKey, testCase.key)
+			}
+
+			fragments := []string{
+				testCase.key,
+				testCase.key[:4],
+				testCase.key[len(testCase.key)-4:],
+			}
+			for _, fragment := range fragments {
+				if strings.Contains(output, fragment) {
+					t.Errorf("stdout leaked API key material %q: %q", fragment, output)
+				}
+			}
+
+			if !strings.Contains(output, "Code completion API Key index:") {
+				t.Errorf("stdout did not include the selected key index: %q", output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Stops logging code-completion API key material in `getRandomApiKey`. The selected key index remains available for diagnostics, while the selected key is returned unchanged for request authentication.

## Security rationale

Partial masking still exposed the first and last four characters of long keys. Those fragments can aid credential correlation and provide unnecessary secret material in application logs. This change removes both full and partial key output.

## Changes

- Removes full and partially masked API key logging.
- Preserves the non-secret selected-key index log.
- Adds an automated stdout regression test for long and short keys.
- Verifies that the full key, prefix, and suffix never appear in logs.
- Verifies that key selection and return behavior remain unchanged.

## Validation

Validated at commit `9171156fd91540e628e88d86f286865dec3b8db3` with Go 1.27.0 (module target: Go 1.21).

- Added regression test file `main_test.go` is gofmt-clean.
- Targeted security regression test passed.
- Full race-enabled test suite passed: `go test -race -count=1 ./...`.
- Static analysis passed: `go vet ./...`.
- Trimmed-path build passed: `go build -trimpath -o /tmp/override-pr94 .`.
- The old partial-masking commit fails the new test because its logged prefix and suffix are detected.
- The current commit passes with no full or partial API key material in stdout.
- Working tree was clean after validation.